### PR TITLE
chore(deps): update dependency http-server to ^0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
-    "http-server": "^0.9.0",
+    "http-server": "^0.11.0",
     "nodemon": "^1.11.0",
     "rimraf": "^2.6.1",
     "swagger-ui": "^3.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,15 +113,19 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@0.9.0, async@~0.9:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.0.tgz#ac3613b1da9bed1b47510bb4651b8931e47146c7"
+async@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^2.0.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.3.0.tgz#1013d1051047dd320fe24e494d5c66ecaf6147d9"
   dependencies:
     lodash "^4.14.0"
+
+async@~0.9:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.0.tgz#ac3613b1da9bed1b47510bb4651b8931e47146c7"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -515,14 +519,14 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-ecstatic@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-1.4.1.tgz#32cb7b6fa2e290d58668674d115e8f0c3d567d6a"
+ecstatic@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ecstatic/-/ecstatic-3.2.0.tgz#1b1aee1ca7c6b99cfb5cf6c9b26b481b90c4409f"
   dependencies:
-    he "^0.5.0"
-    mime "^1.2.11"
+    he "^1.1.1"
+    mime "^1.4.1"
     minimist "^1.1.0"
-    url-join "^1.0.0"
+    url-join "^2.0.2"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -987,9 +991,9 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-he@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-0.5.0.tgz#2c05ffaef90b68e860f3fd2b54ef580989277ee2"
+he@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 headless@^0.1.7:
   version "0.1.7"
@@ -1031,17 +1035,17 @@ http-proxy@^1.11.2, http-proxy@^1.8.1:
     eventemitter3 "1.x.x"
     requires-port "1.x.x"
 
-http-server@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/http-server/-/http-server-0.9.0.tgz#8f1b06bdc733618d4dc42831c7ba1aff4e06001a"
+http-server@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/http-server/-/http-server-0.11.1.tgz#2302a56a6ffef7f9abea0147d838a5e9b6b6a79b"
   dependencies:
     colors "1.0.3"
     corser "~2.0.0"
-    ecstatic "^1.4.0"
+    ecstatic "^3.0.0"
     http-proxy "^1.8.1"
     opener "~1.4.0"
     optimist "0.6.x"
-    portfinder "0.4.x"
+    portfinder "^1.0.13"
     union "~0.4.3"
 
 http-signature@~1.1.0:
@@ -1620,6 +1624,10 @@ mime@1.3.4, mime@^1.2.11, mime@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
@@ -1952,11 +1960,12 @@ plist@^1.0.1:
     xmlbuilder "4.0.0"
     xmldom "0.1.x"
 
-portfinder@0.4.x:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-0.4.0.tgz#a3ffadffafe4fb98e0601a85eda27c27ce84ca1e"
+portfinder@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
   dependencies:
-    async "0.9.0"
+    async "^1.5.2"
+    debug "^2.2.0"
     mkdirp "0.5.x"
 
 prepend-http@^1.0.0:
@@ -2771,9 +2780,9 @@ update-notifier@0.5.0:
     semver-diff "^2.0.0"
     string-length "^1.0.0"
 
-url-join@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/url-join/-/url-join-1.1.0.tgz#741c6c2f4596c4830d6718460920d0c92202dc78"
+url-join@^2.0.2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
 
 url-parse@1.0.x:
   version "1.0.5"


### PR DESCRIPTION
This Pull Request updates dependency [http-server](https://github.com/indexzero/http-server) from `^0.9.0` to `^0.11.0`



<details>
<summary>Release Notes</summary>

### [`v0.10.0`](https://github.com/indexzero/http-server/releases/0.10.0)

- add `-g` (or `--gzip`) parameter to serve `.gz` files when available b456b77c6c476fed0724800ac2c07fa31c647d75
 - update `ecstatic` to `2.0.0` 5da2392b08f14cea4c38fb31378d11c291550ea3
 - use safe colors in console test output a3ace13a97218c27439799f1bbca28cd7f08e294 0da0e1b03af61573805ed27a7799348c31db6b6c
 - update `portfinder` to `1.0.13` 989fa1c7f5727da92ac727f673a2d4b7a121124a

---

</details>


<details>
<summary>Commits</summary>

#### v0.10.0
-   [`7ad8c18`](https://github.com/indexzero/http-server/commit/7ad8c18bf16598b30277d674859813534d50fccd) typofix
-   [`b456b77`](https://github.com/indexzero/http-server/commit/b456b77c6c476fed0724800ac2c07fa31c647d75) Add ecstatic&#x27;s gzip mode
-   [`fed98f2`](https://github.com/indexzero/http-server/commit/fed98f2dbb87f1ea7a793e48a1975c20c9e970fa) Merge pull request #&#8203;293 from SteveVanOpstal/master
-   [`5da2392`](https://github.com/indexzero/http-server/commit/5da2392b08f14cea4c38fb31378d11c291550ea3) Update ecstatic
-   [`da8bfe5`](https://github.com/indexzero/http-server/commit/da8bfe5678d4d857a6d45de2d8019b26b6b50a4f) Merge pull request #&#8203;319 from hmil/ecstatic-v2
-   [`413fe72`](https://github.com/indexzero/http-server/commit/413fe72f8da11c7c5746d16e4a7876450f2d9d8c) Merge pull request #&#8203;268 from mLuby/patch-1
-   [`3fc708c`](https://github.com/indexzero/http-server/commit/3fc708c9bc97323bbad3432d9bb888a229598cb6) Remove jitsu reference &amp; double Usage section
-   [`7ce3a52`](https://github.com/indexzero/http-server/commit/7ce3a524a5fff0ee8d349291200fb961ca3382d9) Add Development section to README
-   [`69acc8b`](https://github.com/indexzero/http-server/commit/69acc8b49a4322155365d806604f3fbd0c12e06d) Add shields
-   [`ef15579`](https://github.com/indexzero/http-server/commit/ef1557959ae6d4d71961285edd8985efe3a1fbe8) Switch to flat shields
-   [`a3ace13`](https://github.com/indexzero/http-server/commit/a3ace13a97218c27439799f1bbca28cd7f08e294) Use safe colors to avoid header problems
-   [`0da0e1b`](https://github.com/indexzero/http-server/commit/0da0e1b03af61573805ed27a7799348c31db6b6c) replace color properties with safe-mode calls
-   [`989fa1c`](https://github.com/indexzero/http-server/commit/989fa1c7f5727da92ac727f673a2d4b7a121124a) Upgrade portfinder to latest 1.0.13
-   [`e72a42a`](https://github.com/indexzero/http-server/commit/e72a42a92496fe0e606ff7c0dac133eeaac7d862) Add myself to the contributors
-   [`a2003c1`](https://github.com/indexzero/http-server/commit/a2003c1d37ea049c788d2ab3d0c7d64ea97e88da) [dist] Version bump. 0.10.0
#### v0.11.0
-   [`ba6db2c`](https://github.com/indexzero/http-server/commit/ba6db2cf0d84944011f80b65318bc2dca4d2ab52) Update Node.js versions to latest list (&gt; 4)
-   [`0803f36`](https://github.com/indexzero/http-server/commit/0803f36fb5359945fbf332081da6ef951b73277d) Remove npm install npm line
-   [`7e9ff0b`](https://github.com/indexzero/http-server/commit/7e9ff0b47164e360186480e5f98dceddeab23b63) Remove extra slashes
-   [`4f3a998`](https://github.com/indexzero/http-server/commit/4f3a9989ffcbda192b6c3d6d2b3b8e50de42334e) Use &quot;files&quot; field in package.json
-   [`966ce9c`](https://github.com/indexzero/http-server/commit/966ce9c27cd3596b74859c94b4e68346565bd8d3) Adds --hide-dotfiles option
-   [`402ad49`](https://github.com/indexzero/http-server/commit/402ad49faea69ad19fc9cca408446612907760b7) Merge branch &#x27;johntron-feature/dotfiles-visibility&#x27;
-   [`73fb2e8`](https://github.com/indexzero/http-server/commit/73fb2e865ecb5875bfc91082d0f18d6b520d59d8) Upgrade ecstatic to 3.0.0
-   [`7117493`](https://github.com/indexzero/http-server/commit/711749368b235e867dc783129c4775c3ced27fbb) [dist] Version bump. 0.11.0
#### v0.11.1
-   [`2372798`](https://github.com/indexzero/http-server/commit/23727988ba0207ccfeb0b46ac68ed9661c5291c1) [dist] Version bump. 0.11.1

</details>